### PR TITLE
Add dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,20 +4,46 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    tags:        
-      - 'v*.*.*'
+    tags:
+      - '*.*.*'
+
+env:
+  IMAGE_TAG: ${{ github.event.number || github.ref_name }}
 
 jobs:
-  docker:
+  docker-build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Docker Build
         run: |
-          echo "docker build..."
+          docker build -t ${{ github.repository }}:${{ env.IMAGE_TAG }} .
+          docker save -o image.tar ${{ github.repository }}:${{ env.IMAGE_TAG }}
+
+      - name: Upload Docker Image
+        uses: actions/upload-artifact@v4
+        with:
+          name: Image
+          path: ${{ github.repository }}-${{ env.IMAGE_TAG }}.tar
+
+  promote-dev:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: docker-build
+    steps:
+      - name: Download Docker Image
+        uses: actions/download-artifact@v4
+        with:
+          name: Image
 
       - name: Docker Push
-        if: github.event_name != 'pull_request'
         run: |
-          TAG_NAME=${{ github.ref }}
-          TAG_NAME=${TAG_NAME#refs/tags/}
-          echo "docker push tag $TAG_NAME to registry..."
+          docker load -i image.tar
+          docker images
+          echo "docker push"
+
+      - name: Create PR
+        run: |
+          echo "Creating PR..."

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   IMAGE_TAG: ${{ github.event.number || github.ref_name }}
+  ARTIFACT: image.tar
 
 jobs:
   docker-build:
@@ -20,13 +21,13 @@ jobs:
       - name: Docker Build
         run: |
           docker build -t ${{ github.repository }}:${{ env.IMAGE_TAG }} .
-          docker save -o image.tar ${{ github.repository }}:${{ env.IMAGE_TAG }}
+          docker save -o ${{ env.ARTIFACT }} ${{ github.repository }}:${{ env.IMAGE_TAG }}
 
       - name: Upload Docker Image
         uses: actions/upload-artifact@v4
         with:
           name: Image
-          path: ${{ github.repository }}-${{ env.IMAGE_TAG }}.tar
+          path: ${{ env.ARTIFACT }}
 
   promote-dev:
     if: github.event_name != 'pull_request'
@@ -40,7 +41,7 @@ jobs:
 
       - name: Docker Push
         run: |
-          docker load -i image.tar
+          docker load -i ${{ env.ARTIFACT }}
           docker images
           echo "docker push"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.13-alpine
+
+COPY app/ /app
+
+WORKDIR /app
+
+CMD ["python", "main.py"]


### PR DESCRIPTION
This pull request includes significant updates to the Docker build workflow and the addition of a new `Dockerfile` for building a Python application. The most important changes are summarized below:

### Workflow Improvements:

* Modified the `on:` section in `.github/workflows/docker-build.yml` to trigger on any tag pattern (`*.*.*` instead of `v*.*.*`).
* Renamed the job from `docker` to `docker-build` and added a new job `promote-dev` that depends on `docker-build`.
* Enhanced the Docker build step to save the Docker image as a tar file and upload it as an artifact.
* Added steps to download the Docker image artifact in the `promote-dev` job and load it before pushing the image.

### Dockerfile Addition:

* Introduced a new `Dockerfile` that uses `python:3.13-alpine`, copies the application files, sets the working directory, and specifies the command to run the application.